### PR TITLE
feat(secrets): add support for secrets

### DIFF
--- a/Documentation/DOCUMENTATION.md
+++ b/Documentation/DOCUMENTATION.md
@@ -1327,6 +1327,146 @@ pass in an empty string to bearer_token when calling
     puts yaml_client.delete_configmap(namespace, configmap_name, yaml_file_path) # Returns JSON
 ```
 
+#### Create Secret
+* Create new Secret in Namespace
+* Config options documentation available at: https://kubernetes.io/docs/concepts/configuration/secret/
+```ruby
+    require 'ruby-kubernetes-controller'
+    
+    endpoint = "localhost"
+    bearer_token = "token"
+    ssl = false
+    
+    # Create new Secret
+    secret = '{
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": "my-secret",
+            "namespace": "default"
+        },
+        "data": {
+            "username": "base64-encoded-username",
+            "password": "base64-encoded-password"
+        }
+    }'
+    
+    client = ::RubyKubernetesController::Client.new(endpoint, bearer_token, ssl)
+    puts client.create_new_secret("default", secret) # Returns JSON
+```
+
+#### Get All Secrets
+* List all Secrets
+```ruby
+    require 'ruby-kubernetes-controller'
+    
+    endpoint = "localhost"
+    bearer_token = "token"
+    ssl = false
+    
+    client = ::RubyKubernetesController::Client.new(endpoint, bearer_token, ssl)
+    
+    puts client.get_all_secrets # Returns JSON
+```
+
+#### Get All Secrets in a Namespace
+* List all Secrets in a specific Namespace
+```ruby
+    require 'ruby-kubernetes-controller'
+    
+    endpoint = "localhost"
+    bearer_token = "token"
+    ssl = false
+    
+    client = ::RubyKubernetesController::Client.new(endpoint, bearer_token, ssl)
+    
+    namespace = "default"
+    
+    puts client.get_all_namespaced_secrets(namespace) # Returns JSON
+```
+
+#### Get Single Namespaced Secret
+* Get details for a single Secret in a Namespace
+```ruby
+    require 'ruby-kubernetes-controller'
+    
+    endpoint = "localhost"
+    bearer_token = "token"
+    ssl = false
+    
+    client = ::RubyKubernetesController::Client.new(endpoint, bearer_token, ssl)
+    
+    namespace = "default"
+    secret_name = "my-secret"
+    
+    puts client.get_single_namespaced_secret(namespace, secret_name) # Returns JSON
+```
+
+#### Update Secret
+* Update existing Secret in Namespace
+```ruby
+    require 'ruby-kubernetes-controller'
+    
+    endpoint = "localhost"
+    bearer_token = "token"
+    ssl = false
+    
+    # Update existing Secret
+    update = '{
+    "metadata": {
+        "name": "my-secret"
+    },
+    "data": {
+        "username": "base64-encoded-username",
+        "password": "base64-encoded-password"
+    }
+    }'
+    
+    client = ::RubyKubernetesController::Client.new(endpoint, bearer_token, ssl)
+    namespace = "default"
+    secret_name = "my-secret"
+    
+    puts client.update_secret(namespace, secret_name, update) # Returns JSON
+```
+
+#### Patch Secret
+* Patch existing Secret in Namespace
+```ruby
+    require 'ruby-kubernetes-controller'
+    
+    endpoint = "localhost"
+    bearer_token = "token"
+    ssl = false
+    
+    # Patch existing Secret
+    patch = '[
+      { "op": "replace", "path": "/data/username", "value": "new-base64-encoded-username" }
+    ]'
+    
+    client = ::RubyKubernetesController::Client.new(endpoint, bearer_token, ssl)
+    namespace = "default"
+    secret_name = "my-secret"
+    
+    puts client.patch_secret(namespace, secret_name, patch) # Returns JSON
+```
+
+#### Delete Secret
+* Delete existing Secret in Namespace
+```ruby
+    require 'ruby-kubernetes-controller'
+    
+    endpoint = "localhost"
+    bearer_token = "token"
+    ssl = false
+    
+    client = ::RubyKubernetesController::Client.new(endpoint, bearer_token, ssl)
+    
+    namespace = "default"
+    secret_name = "my-secret"
+    
+    puts client.delete_secret(namespace, secret_name) # Returns JSON
+```
+
 #### Create PersistentVolume
 * Create new PersistentVolume
 * Config options documentation available at: https://kubernetes.io/docs/reference/federation/v1/definitions/#_v1_persistentvolume

--- a/lib/ruby-kubernetes-controller/client.rb
+++ b/lib/ruby-kubernetes-controller/client.rb
@@ -18,6 +18,7 @@ require_relative 'persistentvolumeclaims'
 require_relative 'jobs'
 require_relative 'cronjob'
 require_relative 'utilities'
+require_relative 'secrets'
 
 # Part of the RubyKubernetesController module
 module RubyKubernetesController
@@ -40,6 +41,7 @@ module RubyKubernetesController
     include Jobs
     include CronJobs
     include Utilities
+    include Secrets
 
     # Constructor
     def initialize(endpoint, bearer_token, ssl = true, yaml = false)

--- a/lib/ruby-kubernetes-controller/secrets.rb
+++ b/lib/ruby-kubernetes-controller/secrets.rb
@@ -1,0 +1,133 @@
+require 'net/http'
+require 'uri'
+require 'openssl'
+require 'json'
+require_relative 'generic'
+module Secrets
+  include Generic
+  # Create new Secret
+  def create_new_secret(namespace, secret)
+    extension = "/api/v1/namespaces/#{namespace}/secrets"
+    uri = prepareURI(@endpoint, extension)
+    request = prepareGenericRequest(uri, @bearer_token,  "POST")
+    request.content_type = "application/json"
+    if @yaml
+      request.body = yaml_file_to_json(secret)
+    else
+      request.body = secret
+    end
+    req_options = prepareGenericRequestOptions(@ssl, uri)
+    begin
+      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+        http.request(request)
+      end
+      return response.body
+    rescue Errno::ECONNREFUSED
+      raise "Connection for host #{uri.hostname} refused"
+    end
+  end
+  # Get all Secrets
+  def get_all_secrets
+    extension = "/api/v1/secrets"
+    uri = prepareURI(@endpoint, extension)
+    request = prepareGenericRequest(uri, @bearer_token, "GET")
+    req_options = prepareGenericRequestOptions(@ssl, uri)
+    begin
+      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+        http.request(request)
+      end
+      return response.body
+    rescue Errno::ECONNREFUSED
+      raise "Connection for host #{uri.hostname} refused"
+    end
+  end
+  # Get all Secrets in a Namespace
+  def get_all_namespaced_secrets(namespace)
+    extension = "/api/v1/namespaces/#{namespace}/secrets"
+    uri = prepareURI(@endpoint, extension)
+    request = prepareGenericRequest(uri, @bearer_token, "GET")
+    req_options = prepareGenericRequestOptions(@ssl, uri)
+    begin
+      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+        http.request(request)
+      end
+      return response.body
+    rescue Errno::ECONNREFUSED
+      raise "Connection for host #{uri.hostname} refused"
+    end
+  end
+  # Get a single Secret from a Namespace
+  def get_single_namespaced_secret(namespace, secret_name)
+    extension = "/api/v1/namespaces/#{namespace}/secrets/#{secret_name}"
+    uri = prepareURI(@endpoint, extension)
+    request = prepareGenericRequest(uri, @bearer_token, "GET")
+    req_options = prepareGenericRequestOptions(@ssl, uri)
+    begin
+      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+        http.request(request)
+      end
+      return response.body
+    rescue Errno::ECONNREFUSED
+      raise "Connection for host #{uri.hostname} refused"
+    end
+  end
+  # Update existing Secret in Namespace
+  def update_secret(namespace, secret_name, update)
+    extension = "/api/v1/namespaces/#{namespace}/secrets/#{secret_name}"
+    uri = prepareURI(@endpoint, extension)
+    request = prepareGenericRequest(uri, @bearer_token, "PUT")
+    request.content_type = "application/json"
+    if @yaml
+      request.body = yaml_file_to_json(update)
+    else
+      request.body = update
+    end
+    req_options = prepareGenericRequestOptions(@ssl, uri)
+    begin
+      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+        http.request(request)
+      end
+      return response.body
+    rescue Errno::ECONNREFUSED
+      raise "Connection for host #{uri.hostname} refused"
+    end
+  end
+  # Patch existing Secret in Namespace
+  def patch_secret(namespace, secret_name, patch)
+    extension = "/api/v1/namespaces/#{namespace}/secrets/#{secret_name}"
+    uri = prepareURI(@endpoint, extension)
+    request = prepareGenericRequest(uri, @bearer_token, "PATCH")
+    request.content_type = "application/json-patch+json"
+    request.body = patch
+    req_options = prepareGenericRequestOptions(@ssl, uri)
+    begin
+      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+        http.request(request)
+      end
+      return response.body
+    rescue Errno::ECONNREFUSED
+      raise "Connection for host #{uri.hostname} refused"
+    end
+  end
+  # Delete existing Secret in Namespace
+  def delete_secret(namespace, secret_name, options = '')
+    extension = "/api/v1/namespaces/#{namespace}/secrets/#{secret_name}"
+    uri = prepareURI(@endpoint, extension)
+    request = prepareGenericRequest(uri, @bearer_token, "DELETE")
+    request.content_type = "application/json"
+    if @yaml
+      request.body = yaml_file_to_json(options)
+    else
+      request.body = options
+    end
+    req_options = prepareGenericRequestOptions(@ssl, uri)
+    begin
+      response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+        http.request(request)
+      end
+      return response.body
+    rescue Errno::ECONNREFUSED
+      raise "Connection for host #{uri.hostname} refused"
+    end
+  end
+end

--- a/test/ruby_kubernetes_controller_test.rb
+++ b/test/ruby_kubernetes_controller_test.rb
@@ -465,6 +465,62 @@ class RubyKubernetesControllerTEST < Minitest::Test
     end
   end
 
+  def test_client_create_new_secret
+    client = ::RubyKubernetesController::Client.new("localhost", "TOKEN", false)
+  
+    assert_raises Exception do
+      client.create_new_secret('default', '{"kind": "Secret","apiVersion": "v1"}')
+    end
+  end
+  
+  def test_client_get_all_secrets
+    client = ::RubyKubernetesController::Client.new("localhost", "TOKEN", false)
+  
+    assert_raises Exception do
+      client.get_all_secrets
+    end
+  end
+  
+  def test_client_get_all_namespaced_secrets
+    client = ::RubyKubernetesController::Client.new("localhost", "TOKEN", false)
+  
+    assert_raises Exception do
+      client.get_all_namespaced_secrets('default')
+    end
+  end
+  
+  def test_client_get_single_namespaced_secret
+    client = ::RubyKubernetesController::Client.new("localhost", "TOKEN", false)
+  
+    assert_raises Exception do
+      client.get_single_namespaced_secret('default', 'my-secret')
+    end
+  end
+  
+  def test_client_update_secret
+    client = ::RubyKubernetesController::Client.new("localhost", "TOKEN", false)
+  
+    assert_raises Exception do
+      client.update_secret('default', 'my-secret', '{"kind": "Secret","apiVersion": "v1"}')
+    end
+  end
+  
+  def test_client_patch_secret
+    client = ::RubyKubernetesController::Client.new("localhost", "TOKEN", false)
+  
+    assert_raises Exception do
+      client.patch_secret('default', 'my-secret', '{"op": "replace", "path": "/data", "value": "new-value"}')
+    end
+  end
+  
+  def test_client_delete_secret
+    client = ::RubyKubernetesController::Client.new("localhost", "TOKEN", false)
+  
+    assert_raises Exception do
+      client.delete_secret('default', 'my-secret', '{"kind": "Secret","apiVersion": "v1"}')
+    end
+  end
+
   def test_client_create_new_job
     client = ::RubyKubernetesController::Client.new("localhost", "TOKEN", false)
 


### PR DESCRIPTION
closes #11 

- Implemented methods to create, retrieve, update, patch, and delete Secrets in Kubernetes.
- Added corresponding documentation examples in the Documentation.md file.
- Included tests for each new method in ruby_kubernetes_controller_test.rb to ensure functionality.
